### PR TITLE
change varible used for completion status to the one used to control …

### DIFF
--- a/03_Model_customization/03_continued_pretraining_titan_text.ipynb
+++ b/03_Model_customization/03_continued_pretraining_titan_text.ipynb
@@ -449,7 +449,7 @@
     "\n",
     "while training_job_status == \"InProgress\":\n",
     "    time.sleep(60)\n",
-    "    fine_tune_job = bedrock.get_model_customization_job(jobIdentifier=customization_job_name)[\"status\"]\n",
+    "    training_job_status = bedrock.get_model_customization_job(jobIdentifier=customization_job_name)[\"status\"]\n",
     "    print (training_job_status)"
    ]
   },


### PR DESCRIPTION
…the loop

The 2nd step in the Check Customization Job Status section of 03_Model_customization/03_continued_pretraining_titan_text.ipynb never completes as the while variable is not changed in the loop  #225